### PR TITLE
Update Fake_News_Getting_started_and_Data_Analysis.ipynb

### DIFF
--- a/Fake_News/Fake_News_Getting_started_and_Data_Analysis.ipynb
+++ b/Fake_News/Fake_News_Getting_started_and_Data_Analysis.ipynb
@@ -3268,7 +3268,7 @@
    ],
    "source": [
     "%%timeit\n",
-    "original_train_df['avg_word_length'] = original_train_df['sent_word_tokens'].apply(lambda x: get_average_words_in_sent(x))"
+    "original_train_df['avg_word_length'] = original_train_df['sent_word_tokens'].apply(lambda x: get_average_word_length(x))"
    ]
   },
   {


### PR DESCRIPTION
In Stylometric Analysis, when creating the column 'avg_word_length' for the average word length per article, the function **get_average_words_in_sent** was called but **get_average_word_length** should be called instead.